### PR TITLE
fix the multiple backend remove method to check for multi queue and pass...

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -22,6 +22,11 @@ module Resque
         @backends.each(&:save)
       end
 
+      # Returns an array of all the failed queues in the system
+      def self.queues
+        classes.first.queues
+      end
+
       # The number of failures.
       def self.count(*args)
         classes.first.count(*args)
@@ -51,8 +56,14 @@ module Resque
         classes.first.requeue(*args)
       end
 
-      def self.remove(index)
-        classes.each { |klass| klass.remove(index) }
+      def self.remove(*args)
+        classes.each { |klass|
+          if klass == Resque::Failure::RedisMultiQueue
+            klass.remove(*args)
+          else
+            klass.remove(args.first)
+          end
+        }
       end
     end
   end


### PR DESCRIPTION
... all arguments to the multi queue and only the first to other backends. Also return the queues for the first backend so that resque web will work with multiple backends and multi queue
